### PR TITLE
Respect updated minutes when starting timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A beginner-friendly Pomodoro timer built with HTML, CSS, and JavaScript, perfect
 - Separate `styles.css` and `script.js` files for clarity.
 - Toggle between dark and light themes.
 - Short beep sound when switching between Focus and Break phases.
+- Editing Focus/Break minutes while idle updates the countdown immediately.
 
 ## How to Run
 - Download the repo or clone it.

--- a/script.js
+++ b/script.js
@@ -41,6 +41,9 @@ function nextPhase() {
 // Start the timer
 function start() {
   if (state.ticking) return;
+  // Respect current input value when starting from idle
+  const mins = state.mode === 'focus' ? +focusEl.value : +breakEl.value;
+  state.remaining = mins * 60 * 1000;
   state.ticking = true;
   state.endAt = performance.now() + state.remaining;
   startBtn.disabled = true;
@@ -88,6 +91,23 @@ startBtn.onclick = start;
 pauseBtn.onclick = pause;
 resetBtn.onclick = reset;
 themeBtn.onclick = toggleTheme;
+
+// Update display when user edits minutes while timer is idle
+focusEl.oninput = () => {
+  if (!state.ticking && state.mode === 'focus') {
+    state.remaining = (+focusEl.value) * 60 * 1000;
+    state.rafId && cancelAnimationFrame(state.rafId);
+    update();
+  }
+};
+
+breakEl.oninput = () => {
+  if (!state.ticking && state.mode === 'break') {
+    state.remaining = (+breakEl.value) * 60 * 1000;
+    state.rafId && cancelAnimationFrame(state.rafId);
+    update();
+  }
+};
 
 // Initialize timer
 reset();

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,83 @@
+// Simple tests for the Pomodoro timer
+// Uses Node's vm module with a tiny DOM stub
+const assert = require('assert');
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+// Create minimal DOM elements needed by the timer
+function createElement() {
+  return {
+    textContent: '',
+    value: '',
+    disabled: false,
+    onclick: null,
+    oninput: null,
+    classList: { toggle() {}, contains() { return false; } },
+    click() { this.onclick && this.onclick(); }
+  };
+}
+
+function setup() {
+  const elements = {
+    display: createElement(),
+    mode: createElement(),
+    focus: Object.assign(createElement(), { value: '25' }),
+    break: Object.assign(createElement(), { value: '5' }),
+    start: createElement(),
+    pause: createElement(),
+    reset: createElement(),
+    theme: createElement()
+  };
+  const document = {
+    body: createElement(),
+    getElementById(id) { return elements[id]; }
+  };
+  const context = {
+    document,
+    performance: { now: () => Date.now() },
+    requestAnimationFrame: (cb) => setTimeout(() => cb(), 0),
+    cancelAnimationFrame: (id) => clearTimeout(id)
+  };
+  context.window = context; // script expects a window global
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
+  vm.runInContext(code, context); // loads timer into context
+  return { context, elements };
+}
+
+function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// Test changing Focus minutes before starting
+async function testFocusStart() {
+  const { context, elements } = setup();
+  elements.focus.value = '10';
+  elements.focus.oninput();
+  assert.strictEqual(elements.display.textContent, '10:00');
+  elements.start.click();
+  await delay(5);
+  assert(elements.display.textContent.startsWith('10:'), 'Focus should start from edited value');
+  context.pause();
+  return { context, elements };
+}
+
+// Test changing Break minutes while idle in Break mode
+async function testBreakStart(env) {
+  const { context, elements } = env;
+  // Manually move to Break mode and keep timer idle
+  vm.runInContext('state.mode="break"; modeEl.textContent="Break"; state.ticking=false; startBtn.disabled=false; pauseBtn.disabled=true; state.remaining=(+breakEl.value)*60*1000; update();', context);
+  elements.break.value = '3';
+  elements.break.oninput();
+  assert.strictEqual(elements.display.textContent, '3:00');
+  elements.start.click();
+  await delay(5);
+  assert(elements.display.textContent.startsWith('3:'), 'Break should start from edited value');
+}
+
+(async () => {
+  const env = await testFocusStart();
+  await testBreakStart(env);
+  console.log('All tests passed');
+  process.exit(0);
+})();
+


### PR DESCRIPTION
## Summary
- ensure Start uses current focus/break minutes when timer is idle
- update display instantly when editing minutes in the active mode
- add tests for Focus and Break minute edits starting from new values

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897ab5f458083338a36913769c184e6