### PR TITLE
Add browser-based Mocha/Chai smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ A beginner-friendly Pomodoro timer built with HTML, CSS, and JavaScript, perfect
 
 ## Ideas for Codex Tasks
 - Add presets for different focus/break times.
+
+## How to Run Tests
+- Open `tests/test.html` in your browser.
+- All tests should pass; the results appear on the page.
+- Refresh the page to run the tests again.

--- a/tests/test.html
+++ b/tests/test.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Pomodoro Tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <main class="card" aria-live="polite">
+    <div class="theme-toggle">
+      <button id="theme">Light Mode</button>
+    </div>
+    <h1>Pomodoro Timer</h1>
+    <div class="timer" id="display" aria-label="time remaining">25:00</div>
+    <div class="mode" id="mode">Focus</div>
+
+    <div class="row">
+      <label>Focus (min)
+        <input id="focus" type="number" min="1" max="120" value="25" />
+      </label>
+      <label>Break (min)
+        <input id="break" type="number" min="1" max="60" value="5" />
+      </label>
+    </div>
+
+    <div class="buttons">
+      <button id="start" class="primary">Start</button>
+      <button id="pause">Pause</button>
+      <button id="reset">Reset</button>
+    </div>
+
+    <p class="hint">Tip: adjust minutes, then press Start. It auto-switches Focus ⇄ Break.</p>
+  </main>
+
+  <div id="mocha"></div>
+  <script src="https://unpkg.com/mocha/mocha.js"></script>
+  <script src="https://unpkg.com/chai/chai.js"></script>
+  <script>
+    mocha.setup('bdd');
+    const expect = chai.expect;
+  </script>
+  <script src="../script.js"></script>
+  <script src="test.js"></script>
+  <script>mocha.run();</script>
+</body>
+</html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,96 @@
+// Smoke tests for the Pomodoro timer
+describe('Pomodoro Timer', function() {
+  this.timeout(5000);
+  // Reset the app before and after each test to keep state clean
+  beforeEach(function() {
+    reset();
+  });
+  afterEach(function() {
+    reset();
+  });
+
+  // Helper: convert "m:ss" to total seconds
+  function secs(text) {
+    const [m, s] = text.split(':').map(Number);
+    return m * 60 + s;
+  }
+
+  it('Timer counts down after pressing Start', function(done) {
+    state.remaining = 5000;
+    update();
+    const startTime = secs(display.textContent);
+    start();
+    setTimeout(function() {
+      const later = secs(display.textContent);
+      try {
+        expect(later).to.be.below(startTime);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, 1200);
+  });
+
+  it('Pause stops countdown', function(done) {
+    state.remaining = 5000;
+    update();
+    start();
+    setTimeout(function() {
+      pause();
+      const paused = display.textContent;
+      setTimeout(function() {
+        try {
+          expect(display.textContent).to.equal(paused);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, 1200);
+    }, 100);
+  });
+
+  it('Reset sets the display to the current Focus minutes value', function() {
+    focusEl.value = 10;
+    reset();
+    expect(display.textContent).to.equal('10:00');
+  });
+
+  it('Dark/Light toggle switches theme class', function() {
+    const had = document.body.classList.contains('light');
+    themeBtn.click();
+    expect(document.body.classList.contains('light')).to.equal(!had);
+  });
+
+  it('Beep function is called at phase change', function(done) {
+    const RealAC = window.AudioContext;
+    const RealWAC = window.webkitAudioContext;
+    class FakeOsc { constructor(){ this.frequency={value:0}; this.type=''; } connect(){} start(){} stop(){} }
+    class FakeGain { constructor(){ this.gain={value:0, exponentialRampToValueAtTime(){}}; } connect(){} }
+    class FakeCtx {
+      createOscillator(){ return new FakeOsc(); }
+      createGain(){ return new FakeGain(); }
+      get destination(){ return {}; }
+      get currentTime(){ return 0; }
+    }
+    window.AudioContext = window.webkitAudioContext = FakeCtx;
+    const realBeep = window.beep;
+    let called = 0;
+    window.beep = function(){ called++; realBeep(); };
+    state.remaining = 50;
+    update();
+    start();
+    setTimeout(function(){
+      try {
+        expect(called).to.be.above(0);
+        done();
+      } catch(e){
+        done(e);
+      } finally {
+        window.beep = realBeep;
+        window.AudioContext = RealAC;
+        window.webkitAudioContext = RealWAC;
+        reset();
+      }
+    }, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/tests` folder with `test.html` that loads Mocha and Chai from CDN and runs the Pomodoro app alongside tests
- Write `test.js` smoke tests covering start, pause, reset, theme toggle, and phase-change beep (with fake AudioContext)
- Update README with instructions for running browser tests

## Testing
- `node tests/test.js` *(fails: ReferenceError: describe is not defined — tests require a browser)*

------
https://chatgpt.com/codex/tasks/task_e_6897aabcfc748333b2fdce32876e732a