### PR TITLE
Add GitHub Pages links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # hello-codex-pomodoro
+
+[Live Demo](https://its3ddie.github.io/hello-codex-pomodoro/) · [Test Suite](https://its3ddie.github.io/hello-codex-pomodoro/tests/test.html)
+
 A beginner-friendly Pomodoro timer built with HTML, CSS, and JavaScript, perfect for learning and experimenting with OpenAI Codex.
 
 ## Features


### PR DESCRIPTION
## Summary
- add links to the deployed site and test suite in the README
- include a `.nojekyll` file so Pages serves content from the repo root

## Testing
- `curl -I http://localhost:8090/tests/test.html`
- `npx mocha-headless-chrome -f tests/test.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897ca8dc3748333a4b56f64bbe2b456